### PR TITLE
Init Default DB table.

### DIFF
--- a/BlizzFader.lua
+++ b/BlizzFader.lua
@@ -1517,6 +1517,13 @@ local function OnUpdate(self, elapsed)
 end
 
 local function OnEvent(self, event, ...)
+    --===== Check if BlizzFaderDB is empty, if yes then initialize deafults. =====--
+    if event == "PLAYER_ENTERING_WORLD" then
+        if not BlizzFaderDB.opacity then
+            BlizzFaderDB = defaultBlizzFaderDB 
+        end
+    end
+
     if event == "PLAYER_ENTERING_WORLD" or event == "PARTY_MEMBERS_CHANGED" then
         GetFrames()
         if frameCount > 0 then


### PR DESCRIPTION
Initialize **defaultBlizzFaderDB** table **IF** no settings are yet found, **AND** only on _PLAYER_ENTERING_WORLD_ event.